### PR TITLE
Default to Resend onboarding sender and warn when RESEND_FROM is unset

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -116,7 +116,8 @@ export async function POST(request: Request) {
   const normalizedCountry = country?.trim() || "";
   const normalizedTopic = topic?.trim() || "General inquiry";
   const apiKey = process.env.RESEND_API_KEY;
-  const from = process.env.RESEND_FROM ?? "contact@dataconsulting-group.com";
+  const defaultFrom = "DCG Contact <onboarding@resend.dev>";
+  const from = process.env.RESEND_FROM ?? defaultFrom;
   const to = process.env.RESEND_TO ?? "botos.levente2007@gmail.com";
 
   if (!apiKey) {
@@ -125,6 +126,13 @@ export async function POST(request: Request) {
       { error: "Email service is not configured.", requestId },
       logs,
       500
+    );
+  }
+
+  if (from === defaultFrom) {
+    log(
+      "warn",
+      "RESEND_FROM not set; using Resend onboarding sender address."
     );
   }
 


### PR DESCRIPTION
### Motivation
- Prevent contact deliveries from failing due to an unverified custom domain by falling back to a verified Resend onboarding sender when `RESEND_FROM` is not configured.

### Description
- Added a `defaultFrom` (`"DCG Contact <onboarding@resend.dev>"`) and use `process.env.RESEND_FROM ?? defaultFrom` for the sender in `app/api/contact/route.ts`.
- Log a warning with `log("warn", ...)` when the code falls back to the onboarding sender so operators can notice and configure `RESEND_FROM` with a verified domain.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a23a4e908330b68a85271d28f562)