### PR TITLE
Improve mobile navbar: auto-hide on scroll, transparent at top, full‑screen menu, larger icon toggle

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -42,7 +42,7 @@ export default function Header() {
           </NavBody>
 
           {/* Mobile */}
-          <MobileNav>
+          <MobileNav isMenuOpen={isMobileMenuOpen}>
             <MobileNavHeader>
               <NavbarLogo />
               <MobileNavToggle

--- a/components/ui/resizable-navbar.tsx
+++ b/components/ui/resizable-navbar.tsx
@@ -43,6 +43,8 @@ interface MobileNavProps {
 interface MobileNavHeaderProps {
   children: React.ReactNode;
   className?: string;
+  isAtTop?: boolean;
+  isMenuOpen?: boolean;
 }
 
 interface MobileNavMenuProps {
@@ -186,14 +188,28 @@ export const MobileNav = ({
         opacity: isHidden ? 0 : 1,
       }}
       transition={{ type: "spring", stiffness: 200, damping: 30 }}
+      data-at-top={isAtTop}
       className={cn(
         "fixed inset-x-0 top-0 z-50 flex w-full flex-col items-start justify-between gap-3 px-4 py-3 lg:hidden",
-        isAtTop ? "bg-transparent shadow-none" : "bg-white/95 shadow-sm",
+        isAtTop ? "bg-transparent shadow-none" : "bg-white shadow-sm",
         isHidden ? "pointer-events-none" : "pointer-events-auto",
         className
       )}
     >
-      {children}
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(
+              child as React.ReactElement<{
+                isAtTop?: boolean;
+                isMenuOpen?: boolean;
+              }>,
+              {
+                isAtTop,
+                isMenuOpen,
+              }
+            )
+          : child
+      )}
     </motion.div>
   );
 };
@@ -201,7 +217,11 @@ export const MobileNav = ({
 export const MobileNavHeader = ({
   children,
   className,
+  isAtTop = false,
+  isMenuOpen = false,
 }: MobileNavHeaderProps) => {
+  const shouldInvert = isAtTop && !isMenuOpen;
+
   return (
     <div
       className={cn(
@@ -209,7 +229,14 @@ export const MobileNavHeader = ({
         className
       )}
     >
-      {children}
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(
+              child as React.ReactElement<{ inverted?: boolean }>,
+              { inverted: shouldInvert }
+            )
+          : child
+      )}
     </div>
   );
 };
@@ -263,16 +290,21 @@ export const MobileNavMenu = ({
 export const MobileNavToggle = ({
   isOpen,
   onClick,
+  inverted = false,
 }: {
   isOpen: boolean;
   onClick: () => void;
+  inverted?: boolean;
 }) => {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-      className="flex items-center justify-center text-black"
+      className={cn(
+        "flex items-center justify-center transition-colors",
+        inverted ? "text-white" : "text-black"
+      )}
     >
       {isOpen ? (
         <IconX className="h-8 w-8" />
@@ -283,7 +315,7 @@ export const MobileNavToggle = ({
   );
 };
 
-export const NavbarLogo = () => {
+export const NavbarLogo = ({ inverted = false }: { inverted?: boolean }) => {
   return (
     <a
       href="/"
@@ -292,7 +324,10 @@ export const NavbarLogo = () => {
       <img
         src="/logo.png"
         alt="logo"
-        className="h-8 invert md:invert-0 md:brightness-[25%] md:h-8"
+        className={cn(
+          "h-8 md:h-8 md:invert-0 md:brightness-[25%]",
+          inverted ? "invert" : "invert-0 brightness-[25%]"
+        )}
       />
       {/* <span className="font-medium text-black ">Startup</span> */}
     </a>


### PR DESCRIPTION
### Motivation
- Make the mobile navbar disappear on downward scroll and remain transparent when the page is at the top/hero section.  
- Replace the bordered hamburger button with a larger icon-only control.  
- When opened, have mobile nav links occupy the whole screen on a white background for a focused, full-screen menu experience.

### Description
- Added an `isMenuOpen` prop to `MobileNav` and updated `components/Navbar.tsx` to pass the mobile menu state.  
- Implemented scroll tracking in `MobileNav` using `useScroll` and `useMotionValueEvent` to toggle `isHidden` and `isAtTop`, and disabled hide-on-scroll while the menu is open.  
- Animated the mobile header with `motion` to slide out on downward scroll and to switch between `bg-transparent` at top and `bg-white/95` when scrolled.  
- Converted the toggle from the `Button` component to a plain `button` with larger icons and changed `MobileNavMenu` to a full-screen fixed overlay (`inset-0`) with `100dvh` height and white background.

### Testing
- Started the dev server with `npm run dev` and the app served `/` successfully (Next dev started and returned HTTP 200).  
- Ran an automated Playwright script that opened a mobile viewport (`375x812`), clicked the nav toggle, and saved a screenshot to `artifacts/mobile-nav-open.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dea3a81bc8330a3c24f70c179018b)