### PR TITLE
Code-split heavy homepage sections with dynamic imports and skeleton fallbacks

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,31 +1,75 @@
+import dynamic from "next/dynamic";
 import SectionTitle from "@/components/SectionTitle";
-import DCGAIPlatformSection from "@/components/DCGAIPlatformSection";
 import ContactCtaSection from "@/components/ContactCtaSection";
-import StrategicQuestionsSection from "@/components/StrategicQuestionsSection";
-import AIAtWorkSection from "@/components/AIAtWorkSection";
-import { WhyDcgBento } from "@/components/WhyDcgBento";
 import HeroVideoSection from "@/components/HeroVideo";
-import AiCompaniesVideo from "@/components/AiCompaniesVideo";
-import HomeDeferredSections, {
-  HomeTimelineSection,
-} from "@/components/HomeDeferredSections";
+
+const WhyDcgBento = dynamic(
+  () => import("@/components/WhyDcgBento").then((module) => module.WhyDcgBento),
+  {
+    loading: () => (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className="min-h-[220px] rounded-2xl border border-slate-200 bg-slate-50/80"
+          />
+        ))}
+      </div>
+    ),
+  }
+);
+
+const StrategicQuestionsSection = dynamic(
+  () => import("@/components/StrategicQuestionsSection"),
+  {
+    loading: () => <div className="min-h-[340px] rounded-2xl bg-slate-50/80" />,
+  }
+);
+
+const DCGAIPlatformSection = dynamic(
+  () => import("@/components/DCGAIPlatformSection"),
+  {
+    loading: () => <div className="min-h-[420px] rounded-2xl bg-slate-50/80" />,
+  }
+);
+
+const HomeTimelineSection = dynamic(
+  () =>
+    import("@/components/HomeDeferredSections").then(
+      (module) => module.HomeTimelineSection
+    ),
+  {
+    loading: () => <div className="min-h-[620px] w-full bg-slate-50/60" />,
+  }
+);
+
+const AIAtWorkSection = dynamic(() => import("@/components/AIAtWorkSection"), {
+  loading: () => <div className="min-h-[460px] rounded-2xl bg-slate-50/80" />,
+});
+
+const AiCompaniesVideo = dynamic(() => import("@/components/AiCompaniesVideo"), {
+  loading: () => <div className="min-h-[440px] w-full bg-slate-50/60" />,
+});
+
+const HomeDeferredSections = dynamic(
+  () => import("@/components/HomeDeferredSections"),
+  {
+    loading: () => <div className="min-h-[720px] w-full bg-slate-50/60" />,
+  }
+);
 
 export default function Home() {
   return (
-    <div className="flex flex-col items-center gap-10 min-h-screen">
-      {/* <HeroSection /> */}
+    <div className="flex min-h-screen flex-col items-center gap-10">
       <HeroVideoSection />
-      {/* <Hero /> */}
-      <div className="mx-auto max-w-7xl px-2 md:px-4 flex flex-col gap-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 px-2 md:px-4">
         <SectionTitle
           title="Unlocking Potential & Delivering Business Value at Speed"
           subtitle="At DCG we impower organizations to transform ambition into impact. Our cutting-edge solutions combine the latest technology, advanced analytics, and deep industry expertise to unlock growth and deliver measurable value."
           nomb={true}
         />
         <WhyDcgBento />
-        {/* <WhyUs /> */}
 
-        {/* <ValuePropositionSection /> */}
         <SectionTitle
           title="We help leaders answer the questions that matter"
           subtitle="From customer growth to AI-ready operating models, we partner with
@@ -56,35 +100,6 @@ export default function Home() {
       </div>
       <AiCompaniesVideo />
       <HomeDeferredSections />
-      {/* <BackgroundRippleEffectDemo /> */}
-      {/* <AIFutureBuiltSection /> */}
-      {/* <BackgroundBeamsWithCollision> */}
-      {/* <div className="relative w-full min-h-96">
-        <DottedGlowBackground
-          className="pointer-events-none [mask-image:radial-gradient(circle_at_center,black_0%,black_40%,transparent_95%)]"
-          opacity={0.5}
-          gap={10}
-          radius={1.6}
-          colorLightVar="--dcg-lightBlue"
-          glowColorLightVar="--dcg-lightGreen"
-          colorDarkVar="--dcg-lightBlue"
-          glowColorDarkVar="--dcg-lightGreen"
-          backgroundOpacity={0}
-          speedMin={0.3}
-          speedMax={1.6}
-          speedScale={1}
-        />
-        <ContactCtaSection
-          eyebrow="Next step"
-          title="Let's build tomorrow together."
-          description="Whether you're exploring your first AI use-cases or scaling an existing data and AI portfolio, we help you move from slideware to impact quickly and responsibly."
-          primaryLabel="Schedule a conversation"
-          primaryHref="/contact"
-          secondaryLabel="Explore services"
-          secondaryHref="/services"
-          className="border-t-0 pt-10 md:pt-12"
-        />
-      </div>{" "} */}
       <ContactCtaSection
         eyebrow="Next step"
         title="Let's build tomorrow together."
@@ -94,7 +109,6 @@ export default function Home() {
         secondaryLabel="Explore services"
         secondaryHref="/services"
       />
-      {/* </BackgroundBeamsWithCollision> */}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Reduce initial JavaScript and improve landing-page performance (LCP/TTI) by deferring animation-rich and client-heavy homepage sections.
- Prevent layout jank by keeping critical hero/CTA server-rendered while loading non-critical sections asynchronously.
- Provide stable layout placeholders to avoid CLS while deferred chunks are fetched.

### Description
- Reworked `app/page.tsx` to use `next/dynamic` for `WhyDcgBento`, `StrategicQuestionsSection`, `DCGAIPlatformSection`, `HomeTimelineSection`, `AIAtWorkSection`, `AiCompaniesVideo`, and `HomeDeferredSections` instead of importing them directly.
- Added lightweight loading placeholders for each dynamic import to preserve layout height and appearance while chunks load.
- Retained `HeroVideoSection` and `ContactCtaSection` as immediately-rendered content to preserve critical-first paint.
- Removed problematic `ssr: false` usages (moved to client-side patterns) to satisfy Server Component rules and committed the change.

### Testing
- Ran `npm run lint`, which failed in this environment due to the project’s `next lint` invocation and local lint configuration issues.
- Ran `npm run build`, which still fails here because the build process cannot fetch Google Fonts from `https://fonts.googleapis.com` in this environment, but the earlier build errors related to `ssr: false` were addressed by the change.
- No runtime unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb95813b7c8330a1ba7ca10c8c6c74)