### PR TITLE
Defer below-the-fold homepage sections and optimize hero logos for mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 import SectionTitle from "@/components/SectionTitle";
 import ContactCtaSection from "@/components/ContactCtaSection";
 import HeroVideoSection from "@/components/HeroVideo";
+import DeferredRender from "@/components/DeferredRender";
 
 const WhyDcgBento = dynamic(
   () => import("@/components/WhyDcgBento").then((module) => module.WhyDcgBento),
@@ -87,7 +88,11 @@ export default function Home() {
         />
         <DCGAIPlatformSection />
       </div>
-      <HomeTimelineSection />
+      <DeferredRender
+        placeholder={<div className="min-h-[620px] w-full bg-slate-50/60" />}
+      >
+        <HomeTimelineSection />
+      </DeferredRender>
       <div className="mx-auto max-w-7xl px-2 md:px-4 flex flex-col gap-10">
         <SectionTitle
           title="Momentum is real. So are the capability gaps."
@@ -98,8 +103,16 @@ export default function Home() {
         />
         <AIAtWorkSection />
       </div>
-      <AiCompaniesVideo />
-      <HomeDeferredSections />
+      <DeferredRender
+        placeholder={<div className="min-h-[440px] w-full bg-slate-50/60" />}
+      >
+        <AiCompaniesVideo />
+      </DeferredRender>
+      <DeferredRender
+        placeholder={<div className="min-h-[720px] w-full bg-slate-50/60" />}
+      >
+        <HomeDeferredSections />
+      </DeferredRender>
       <ContactCtaSection
         eyebrow="Next step"
         title="Let's build tomorrow together."

--- a/components/DeferredRender.tsx
+++ b/components/DeferredRender.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+type DeferredRenderProps = {
+  children: ReactNode;
+  placeholder?: ReactNode;
+  rootMargin?: string;
+  className?: string;
+};
+
+export default function DeferredRender({
+  children,
+  placeholder = null,
+  rootMargin = "300px 0px",
+  className,
+}: DeferredRenderProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isVisible) return;
+
+    const node = containerRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setIsVisible(true);
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(node);
+
+    return () => observer.disconnect();
+  }, [isVisible, rootMargin]);
+
+  return (
+    <div ref={containerRef} className={className}>
+      {isVisible ? children : placeholder}
+    </div>
+  );
+}

--- a/components/HeroVideo.tsx
+++ b/components/HeroVideo.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { track } from "@/lib/analytics";
 import { hasMediaCredits } from "@/lib/media-credits";
@@ -161,13 +162,15 @@ const Hero = () => {
           </p>
           <div className="flex flex-wrap w-full items-center justify-center lg:justify-start gap-2 md:gap-6">
             {trustedClients.map((client) => (
-              <img
+              <Image
                 key={client.name}
                 className="px-4 py-2 h-8 md:h-14 object-contain opacity-75 grayscale"
-                src={client.url}
                 alt={client.name}
+                src={client.url}
+                width={client.width}
+                height={client.height}
+                sizes="(max-width: 768px) 120px, 180px"
                 loading="lazy"
-                decoding="async"
               />
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Reduce initial main-thread work and hydration cost on mobile by deferring non-critical homepage sections until they are near the viewport.
- Improve image delivery and layout stability for the hero trust bar on small screens to lower network and rendering overhead.

### Description
- Add a client-only `DeferredRender` component that uses `IntersectionObserver` to mount children only when they are near the viewport (`components/DeferredRender.tsx`).
- Wrap heavy homepage sections (`HomeTimelineSection`, `AiCompaniesVideo`, and `HomeDeferredSections`) in `DeferredRender` with lightweight placeholders to avoid hydrating those sections on first load (`app/page.tsx`).
- Replace raw `<img>` tags for the hero trusted-client logos with Next.js `<Image>` using explicit `width`/`height` and a `sizes` hint to improve image optimization and reduce layout shift (`components/HeroVideo.tsx`).

### Testing
- Ran `npm run lint` which failed due to the project `next lint` invocation resolving to an invalid directory in this environment (linter did not run successfully).
- Ran `npm run build` which failed in this environment because `next/font` could not fetch the `Inter` font from `https://fonts.googleapis.com` (build blocked by font fetch error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba2cf389083309f6de44dd4a77188)